### PR TITLE
Optimize SSL settings & headers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,11 +11,6 @@ nginx_use_realpath_root: no
 nginx_php_force_cgi_redirect: no
 nginx_set_default_server: yes
 
-nginx_add_headers:
-  - 'Strict-Transport-Security "max-age=63072000 includeSubDomains preload"  always'
-  - X-Content-Type-Options nosniff  always
-  - X-Frame-Options DENY  always
-
 nginx_dhparam_bits: 4096
 
 nginx_http_params_default:
@@ -31,19 +26,26 @@ nginx_http_params_default:
   gzip_min_length: 256
   gzip_types: application/json application/vnd.ms-fontobject application/x-font-ttf application/x-javascript application/xml application/xml+rss font/opentype image/svg+xml image/x-icon text/css text/javascript text/plain text/xml
 
-  ssl_ciphers: '"EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH"'
+  ssl_ciphers: "ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS"
   ssl_dhparam: "/etc/nginx/dh{{ nginx_dhparam_bits }}.pem"
-  ssl_ecdh_curve: secp384r1
   ssl_prefer_server_ciphers: on
-  ssl_protocols: TLSv1.2
-  ssl_session_cache: shared:SSL:10m
+  ssl_protocols: TLSv1 TLSv1.1 TLSv1.2
+  ssl_session_cache: shared:SSL:50m
   ssl_session_tickets: off
+  ssl_session_timeout: 1d
   ssl_stapling: on
   ssl_stapling_verify: on
   resolver: "{{ ansible_dns.nameservers|join(' ') }} valid=300s"
-  resolver_timeout: 5s
-  add_header: "{{ nginx_add_headers }}"
+
+nginx_http_headers_default:
+  Content-Security-Policy: "default-src 'self'; form-action 'self'; frame-ancestors 'none'"
+  Referrer-Policy: "no-referrer, strict-origin-when-cross-origin"
+  Strict-Transport-Security: max-age=15768000
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  X-Xss-Protection: "1; mode=block"
 
 nginx_http_params: {}
+nginx_http_headers: {}
 
 nginx_server_templates: []

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -18,18 +18,18 @@ http {
     access_log  /var/log/nginx/access.log  main;
     error_log   /var/log/nginx/error.log   warn;
 
-{% for key, value in (nginx_http_params_default|combine(nginx_http_params)).iteritems() %}
-{% if key == 'add_header' %}
-{% for header in value %}
-    add_header  {{ header }};
-{% endfor %}
-{% elif value is sameas True %}
+{% for key, value in (nginx_http_params_default | combine(nginx_http_params)).iteritems() %}
+{% if value is sameas True %}
     {{ key }}  on;
 {% elif value is sameas False %}
     {{ key }}  off;
 {% else %}
     {{ key }}  {{ value }};
 {% endif %}
+{% endfor %}
+
+{% for key, value in (nginx_http_headers_default | combine(nginx_http_headers)).iteritems() %}
+    add_header  {{ key }} "{{ value }}"  always;
 {% endfor %}
 
     include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
Best security while supporting older browsers.

Remove `nginx_add_headers` (which was a list) and add `nginx_http_headers` (which is a dictrionary). Also have defaults in `nginx_http_headers_default`, so we can override individual entries easily.

See https://observatory.mozilla.org/analyze.html

After merge, I recommend tagging it as `v3.1.0`