### PR TITLE
Make default config also for port 443 (https)

### DIFF
--- a/files/default.conf
+++ b/files/default.conf
@@ -1,5 +1,6 @@
 server {
     listen       80 default_server;
+    listen       443 default_server;
     server_name  _;
 
     access_log  /var/log/nginx/default.access.log  main;


### PR DESCRIPTION
Problem
======

Since there is no default for port 443 nginx searches the first next config that listens to port 443 and uses this a default.